### PR TITLE
Adds twitter4j.properties.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+conf/twitter4j.properties
 logs
 project/project
 project/target

--- a/conf/.gitignore
+++ b/conf/.gitignore
@@ -1,2 +1,0 @@
-twitter4j.properties
-

--- a/conf/twitter4j.properties
+++ b/conf/twitter4j.properties
@@ -1,0 +1,3 @@
+#twitter4j.debug=true
+twitter4j.oauth.consumerKey=<<PLACE CONSUMER KEY HERE>>
+twitter4j.oauth.consumerSecret=<<PLACE CONSUMER SECRET HERE>>


### PR DESCRIPTION
This patch addes twitter4j.properties.

PARTAKE does not contain twitter4j.properties. So user might be confused when debugging, if he forgot to add twitter4j.properties.

Also, adds .gitignore so that we don't upload twitte4j.properties which includes our debug keys.
