### PR TITLE
fix image paths to match Playframework

### DIFF
--- a/app/views/events/_search.scala.html
+++ b/app/views/events/_search.scala.html
@@ -119,6 +119,11 @@ function render(json) {
             $('#' + prefix + '-image').attr('src', '/images/thumbnail/' + event.foreImageId);
         else
             $('#' + prefix + '-image').attr('src', '/images/no-image.png');
+        
+        // fix image path match Playframework
+        var imgSrc = $('#' + prefix + '-image').attr('src');
+        $('#' + prefix + '-image').attr('src', '@routes.Assets.at("' + imgSrc + '")');
+        
         $('#' + prefix + '-title').attr('href', '/events/' + event.id);
         $('#' + prefix + '-title').text(event.title);
         $('#' + prefix + '-summary').text(event.summary);

--- a/app/views/events/_show_manage_navigation.scala.html
+++ b/app/views/events/_show_manage_navigation.scala.html
@@ -195,7 +195,7 @@
         <h3>リマインダーなどの送付状況</h3>
     </div>
     <div class="modal-body">
-        <div id="event-reminder-dialog-spinner"><img src="/img/spinner.gif"></div>
+        <div id="event-reminder-dialog-spinner"><img src="@routes.Assets.at("/img/spinner.gif")"></div>
         <ul id="event-reminder-list">
         </ul>
     </div>

--- a/app/views/events/show.scala.html
+++ b/app/views/events/show.scala.html
@@ -22,7 +22,7 @@
 
 <div class="page-header">
     <h1>
-    	@if(event.isPrivate()) {<img src="@routes.Assets.at("/images/private.png") title="非公開イベント" />}
+    	@if(event.isPrivate()) {<img src="@routes.Assets.at("images/private.png")" title="非公開イベント" />}
 		@event.getTitle()
         @if(event.isDraft()) {<span class="label label-important">このイベントはまだ公開されていません</span>}
     </h1>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -25,9 +25,9 @@
     <div class="span16">
         @if(ctx.loginUser() != null) {
         <h3>近日開催の参加予定イベント</h3>
-        <div id="upcoming-participating-events"><img src="img/spinner.gif"></div>
+        <div id="upcoming-participating-events"><img src="@routes.Assets.at("img/spinner.gif")"></div>
         <h3>近日開催の管理イベント</h3>
-        <div id="upcoming-managing-events"><img src="img/spinner.gif"></div>
+        <div id="upcoming-managing-events"><img src="@routes.Assets.at("img/spinner.gif")"></div>
         <script>
         partake.account.getTickets('upcoming', 0, 10)
         .done(function(json) {

--- a/app/views/internal/header.scala.html
+++ b/app/views/internal/header.scala.html
@@ -201,7 +201,7 @@
             })
             .fail(partake.defaultFailHandler);
         });
-    }
+    });
     </script>
 </div>
 

--- a/app/views/mypage/_enrollment_table.scala.html
+++ b/app/views/mypage/_enrollment_table.scala.html
@@ -36,7 +36,7 @@
             var tr = $('<tr></tr>');
 
             if (event.isPrivate)
-                $('<td><img src="/images/private.png" title="非公開イベント" /></td>').appendTo(tr);
+                $('<td><img src="@routes.Assets.at("/images/private.png")" title="非公開イベント" /></td>').appendTo(tr);
             else
                 $('<td>&nbsp;</td>').appendTo(tr);
 

--- a/app/views/mypage/_event_table.scala.html
+++ b/app/views/mypage/_event_table.scala.html
@@ -39,7 +39,7 @@
             var tr = $('<tr></tr>');
 
             if (event.isPrivate)
-                $('<td><img src="/images/private.png" title="非公開イベント" /></td>').appendTo(tr);
+                $('<td><img src="@routes.Assets.at("/images/private.png")" title="非公開イベント" /></td>').appendTo(tr);
             else
                 $('<td>&nbsp;</td>').appendTo(tr);
 

--- a/app/views/users/_enrollment_table.scala.html
+++ b/app/views/users/_enrollment_table.scala.html
@@ -38,7 +38,7 @@
             var tr = $('<tr></tr>');
 
             if (event.isPrivate)
-                $('<td><img src="/images/private.png" title="非公開イベント" /></td>').appendTo(tr);
+                $('<td><img src="@routes.Assets.at("/images/private.png")" title="非公開イベント" /></td>').appendTo(tr);
             else
                 $('<td>&nbsp;</td>').appendTo(tr);
 

--- a/app/views/users/_event_table.scala.html
+++ b/app/views/users/_event_table.scala.html
@@ -39,7 +39,7 @@
             var tr = $('<tr></tr>');
 
             if (event.isPrivate)
-                $('<td><img src="/images/private.png" title="非公開イベント" /></td>').appendTo(tr);
+                $('<td><img src="@routes.Assets.at("/images/private.png")" title="非公開イベント" /></td>').appendTo(tr);
             else
                 $('<td>&nbsp;</td>').appendTo(tr);
 


### PR DESCRIPTION
fix for #337

found candidates like that.

192:views shiketa1999$ find . -type f -name "*html" | xargs grep "img" | grep src | grep -v -e "@" -e attr -e http
./events/_search.scala.html:        <img id="template-image" src="/images/thumbnail/id" alt=""  width="220" height="220" />
./index.scala.html:        <div id="upcoming-participating-events"><img src="img/spinner.gif"></div>
./index.scala.html:        <div id="upcoming-managing-events"><img src="img/spinner.gif"></div>
./mypage/_enrollment_table.scala.html:                $('<td><img src="/images/private.png" title="非公開イベント" /></td>').appendTo(tr);
./mypage/_event_table.scala.html:                $('<td><img src="/images/private.png" title="非公開イベント" /></td>').appendTo(tr);
./users/_enrollment_table.scala.html:                $('<td><img src="/images/private.png" title="非公開イベント" /></td>').appendTo(tr);
./users/_event_table.scala.html:                $('<td><img src="/images/private.png" title="非公開イベント" /></td>').appendTo(tr);
192:views shiketa1999$ 
