### PR TITLE
Save a aspect ratio for the event's image at search result.

### DIFF
--- a/app/views/events/_search.scala.html
+++ b/app/views/events/_search.scala.html
@@ -64,7 +64,7 @@
 
 <div id="template" class="span6 masonry-box" style="margin-bottom: 5px; display:none;"><div class="thumbnail">
     <a id="template-image-link" href="/events/some-id">
-        <img id="template-image" src="/images/thumbnail/id" alt=""  width="220" height="220" />
+        <img id="template-image" src="/images/thumbnail/id" alt="" style="max-width: 220px; max-height: 220px;" />
     </a>
     <div class="caption">
         <h5><a id="template-title" href="/events/some-id">title</a></h5>


### PR DESCRIPTION
Event images at search result are specified its width and height(220px).
So not squre image's aspect ratio are broken.
