### PR TITLE
Specify time zone before unit test.

### DIFF
--- a/test/in/partake/controller/api/event/ModifyAPITest.java
+++ b/test/in/partake/controller/api/event/ModifyAPITest.java
@@ -3,6 +3,9 @@ package in.partake.controller.api.event;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+
+import java.util.TimeZone;
+
 import in.partake.base.DateTime;
 import in.partake.base.TimeUtil;
 import in.partake.base.Util;
@@ -11,9 +14,23 @@ import in.partake.controller.api.APIControllerTest;
 import in.partake.model.dto.Event;
 import in.partake.resource.UserErrorCode;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public class ModifyAPITest extends APIControllerTest {
+    private TimeZone defaultTimeZone;
+
+    @Before
+    public void setTimeZone() {
+        defaultTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Tokyo"));
+    }
+
+    @After
+    public void resetTimeZone() {
+        TimeZone.setDefault(defaultTimeZone);
+    }
 
     @Test
     public void testToModifyWithoutLogin() throws Exception {

--- a/test/in/partake/model/dto/EventTest.java
+++ b/test/in/partake/model/dto/EventTest.java
@@ -8,6 +8,7 @@ import in.partake.model.fixture.TestDataProvider;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.TimeZone;
 
 import net.sf.json.JSONObject;
 
@@ -111,10 +112,16 @@ public final class EventTest extends AbstractPartakeModelTest<Event> {
 
     @Test
     public void testToJsonWhenBeginDateExistsAndEndDateIsNull() {
-        Event event = new Event();
-        event.setBeginDate(new DateTime(0L));
-        JSONObject json = event.toSafeJSON();
-        Assert.assertEquals("1970-01-01 09:00", json.getString("beginDate"));
-        Assert.assertFalse(json.containsKey("endDate"));
+        TimeZone defaultTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Tokyo"));
+        try {
+            Event event = new Event();
+            event.setBeginDate(new DateTime(0L));
+            JSONObject json = event.toSafeJSON();
+            Assert.assertEquals("1970-01-01 09:00", json.getString("beginDate"));
+            Assert.assertFalse(json.containsKey("endDate"));
+        } finally {
+            TimeZone.setDefault(defaultTimeZone);
+        }
     }
 }

--- a/test/in/partake/view/HelperTest.java
+++ b/test/in/partake/view/HelperTest.java
@@ -9,9 +9,23 @@ import java.util.TimeZone;
 
 import junit.framework.Assert;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public final class HelperTest {
+    private TimeZone defaultTimeZone;
+
+    @Before
+    public void setTimeZone() {
+        defaultTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Tokyo"));
+    }
+
+    @After
+    public void resetTimeZone() {
+        TimeZone.setDefault(defaultTimeZone);
+    }
 
     // -----------------------------------------
     // readableDate


### PR DESCRIPTION
Travis CI reports test failure because this test case expects Asia/Tokyo
as default time zone. Now our test code specifies it before test method.
