### PR TITLE
removed unused extension. refs #428

### DIFF
--- a/app/views/events/participants/show.scala.html
+++ b/app/views/events/participants/show.scala.html
@@ -9,7 +9,7 @@
 <div class="subnav subnav-fixed"><div class="container">
     <ul class="nav nav-pills nav-stacked-if-phone">
         <li><a href="#" onclick="window.print()">印刷する</a></li>
-        <li><a href="/events/participants/csv/@(event.getId()).csv">CSVで出力する(UTF-8)</a></li>
+        <li><a href="/events/participants/csv/@event.getId()">CSVで出力する(UTF-8)</a></li>
         <li class="pull-right"><a href="/events/@event.getId()">イベントに戻る</a></li>
     </ul>
 </div></div>


### PR DESCRIPTION
we do not have to add extension to URI.
just remove it would solve our problem.
### note:

correct URL in _show_manage_navigation.scala.html is below:

``` xml
        <li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="#"><img class="hidden-phone-inline" src="@routes.Assets.at("/images/momonga1.png")"/> 参加者管理<b class="caret"></b></a>
            <ul class="dropdown-menu">
                <li><a href="/events/participants/@event.getId()">参加者一覧を表示</a></li>
                <li><a href="/events/participants/csv/@event.getId()">参加者リストを CSV (UTF-8) で出力</a></li>
            </ul>
        </li>
```
