### PR TITLE
wrap eventId by double quote

### DIFF
--- a/app/views/events/_edit_side_information.scala.html
+++ b/app/views/events/_edit_side_information.scala.html
@@ -367,7 +367,7 @@ $('#related-submit').click(function(e) {
 var relatedEventIds = [
     @event.getRelatedEventIds().zipWithIndex.map { relatedEventIdWithIndex =>
         @if(relatedEventIdWithIndex._2 != 0) {,}
-        @relatedEventIdWithIndex._1
+        "@relatedEventIdWithIndex._1"
     }
 ];
 } else {


### PR DESCRIPTION
#423 に対する修正です。

ローカル環境で、関連イベントが０，１，２個の時に期待通り表示されることを手動確認済み。

関連するissue: #435
