### PR TITLE
Ask before finishing modification. refs #418

### DIFF
--- a/app/views/events/_edit_manage_navigation.scala.html
+++ b/app/views/events/_edit_manage_navigation.scala.html
@@ -10,4 +10,15 @@
         <li class="pull-right-if-not-phone"><a href="/events/@event.getId()">編集を終了</a></li>
     </ul>
 </div></div>
-
+<script type="text/javascript">
+// see https://github.com/partakein/partake/issues/418
+$(document).on("click", "a[href!=#]", function(e){
+    function isEditing() {
+        return $("input[type=button]").filter(":visible:enabled").length > 0;
+    }
+    if (isEditing() && !window.confirm("保存していない変更があります。保存しないまま編集を終了し、次のページに行く場合は「OK」を押してください。")) {
+        // cancel saving, and continue to edit
+        e.preventDefault();
+    }
+});
+</script>

--- a/app/views/events/edit_enquete.scala.html
+++ b/app/views/events/edit_enquete.scala.html
@@ -55,7 +55,7 @@
                         <input type="text" /> <span class="help-inline"> <a style="font-size: 20px; font-weight: bold; line-height: 18px;">&times;</a></span>
                     </div>
                     <div class="controls">
-                        <a id="template-add-item">＋項目を追加</a>
+                        <a href="#" id="template-add-item">＋項目を追加</a>
                     </div>
                 </div>
             </fieldset></form>
@@ -68,7 +68,7 @@
 
 <div class="row"><div class="span23 offset1">
     <form class="form-horizontal"><fieldset>
-        <a id="add-new-question">＋ 新しい質問を追加</a>
+        <a id="add-new-question" href="#">＋ 新しい質問を追加</a>
     </fieldset></form>
 </div></div>
 
@@ -115,6 +115,7 @@ $('#template-answertype').change(function () {
 });
 $('#template-item a').click(function() {
     var v = $(this).parent().parent();
+    $("#enquete-submit").attr("disabled", false);
     v.remove();
 });
 function addItem(prefix) {
@@ -152,6 +153,7 @@ $(function() {
         var newPrefix = "q" + idx;
         var cloned = cloneTemplate(newPrefix);
         $('#question-list').append(cloned);
+        $("#enquete-submit").attr("disabled", false);
     });
 });
 
@@ -190,7 +192,7 @@ for (var i = 0; i < initialData.length; ++i) {
 
 <form><fieldset>
     <div class="form-actions">
-        <input type="button" id="enquete-submit" class="btn btn-primary" value="保存">
+        <input type="button" id="enquete-submit" class="btn btn-primary" value="保存" disabled>
         <span id="enquete-submit-info" class="text-info"></span>
     </div>
 </fieldset></form>
@@ -223,11 +225,13 @@ $('#enquete-submit').click(function() {
     var eventId = '@event.getId()';
     partake.event.modifyEnquete(eventId, ids, questions, types, options)
     .done(function (json) {
-        $('#enquete-submit-info').hide();
-        $('#enquete-submit-info').text('保存しました');
-        $('#enquete-submit-info').fadeIn(500);
+        $('#enquete-submit-info').hide().text('保存しました').fadeIn(500);
+        $("#enquete-submit").attr("disabled", true);
     })
     .fail(partake.defaultFailHandler);
+});
+$(document).on("change", "input,select", function(e) {
+    $("#enquete-submit").attr("disabled", false);
 });
 </script>
 

--- a/app/views/events/edit_privacy.scala.html
+++ b/app/views/events/edit_privacy.scala.html
@@ -39,7 +39,7 @@
     </script>
 
     <div class="form-actions">
-        <input id="passcode-submit" type="button" class="btn btn-primary" value="保存">
+        <input id="passcode-submit" type="button" class="btn btn-primary" value="保存" disabled>
         <span id="submit-info" class="text-info"></span>
     </div>
     <script>
@@ -62,11 +62,13 @@
 
         partake.event.modify(eventId, { passcode: passcode })
         .done(function (json) {
-            $('#submit-info').hide();
-            $('#submit-info').text('保存しました');
-            $('#submit-info').fadeIn(500);
+            $('#submit-info').text('保存しました').fadeIn(500);
+            $("#passcode-submit").attr("disabled", true);
         })
         .fail(partake.defaultFailHandler);
+    });
+    $(document).on("change", "input", function(){
+        $("#passcode-submit").attr("disabled", false);
     });
     </script>
 </form>

--- a/app/views/events/edit_ticket.scala.html
+++ b/app/views/events/edit_ticket.scala.html
@@ -100,7 +100,7 @@
 
 <div class="row"><div class="span11 offset1">
     <form class="form-horizontal"><fieldset>
-        <a id="add-new-ticket">＋ 新しいチケットを追加</a>
+        <a id="add-new-ticket" href="#">＋ 新しいチケットを追加</a>
     </fieldset></form>
 </div></div>
 
@@ -132,6 +132,7 @@ $('#template-remove').click(function() {
     var id = $(this).attr('id');
     var prefix = id.substr(0, id.indexOf('-'));
     $('#' + prefix).remove();
+    $("#ticket-submit").attr("disabled", false);
 });
 
 function cloneTemplate(newPrefix) {
@@ -156,6 +157,7 @@ $(function() {
         var newPrefix = "q" + idx;
         var cloned = cloneTemplate(newPrefix);
         $('#ticket-list').append(cloned);
+        $("#ticket-submit").attr("disabled", false);
     });
 });
 
@@ -195,7 +197,7 @@ for (var i = 0; i < initialData.length; ++i) {
 
 <form><fieldset>
     <div class="form-actions">
-        <input type="button" id="ticket-submit" class="btn btn-primary" value="保存">
+        <input type="button" id="ticket-submit" class="btn btn-primary" value="保存" disabled>
         <span id="ticket-submit-info" class="text-info"></span>
     </div>
 </fieldset></form>
@@ -239,11 +241,13 @@ $('#ticket-submit').click(function() {
     var eventId = '@event.getId()';
     partake.event.modifyTicket(eventId, tickets)
     .done(function (json) {
-        $('#ticket-submit-info').hide();
-        $('#ticket-submit-info').text('保存しました');
-        $('#ticket-submit-info').fadeIn(500);
+        $('#ticket-submit-info').hide().text('保存しました').fadeIn(500);
+        $("#ticket-submit").attr("disabled", true);
     })
     .fail(partake.defaultFailHandler);
+});
+$(document).on("change", "input", function(e) {
+    $("#ticket-submit").attr("disabled", false);
 });
 </script>
 


### PR DESCRIPTION
to detect modification, I count number of input box in page.
if page contains visible and enabled input elements, it means
that user is still modifing some attributes of event.

to use button to judge, "save" button should be disabled by default.
I added some code to switch enabled/disabled status of "save" button.

I know that it is bad way for logic to use status of DOM,
but I think it is acceptable in this case: other way costs too much.
