### PR TITLE
fixed issues: refs #409, #447

### DIFF
--- a/app/in/partake/controller/action/auth/VerifyForTwitterAction.java
+++ b/app/in/partake/controller/action/auth/VerifyForTwitterAction.java
@@ -122,13 +122,17 @@ class VerifyForTwitterActionTransaction extends Transaction<UserEx> {
         User user = daos.getUserAccess().find(con, userId);
         if (user == null) {
             user = new User(userId, twitterLinkage.getScreenName(), twitterLinkage.getProfileImageURL(), TimeUtil.getCurrentDateTime(), null);
-        } else if (!verifyUserProfiles(user, twitterLinkage)) {
-            user = new User(user); 
-            user.setScreenName(twitterLinkage.getScreenName());
-            user.setProfileImageURL(twitterLinkage.getProfileImageURL());
+            daos.getUserAccess().put(con, user);
+            user.freeze();
+        } else {
+            if (!verifyUserProfiles(user, twitterLinkage)) {
+                user = new User(user);
+                user.setScreenName(twitterLinkage.getScreenName());
+                user.setProfileImageURL(twitterLinkage.getProfileImageURL());
+                daos.getUserAccess().put(con, user);
+                user.freeze();
+            }
         }
-        daos.getUserAccess().put(con, user);
-        user.freeze();
         return new UserEx(user, twitterLinkage);
     }
 

--- a/app/in/partake/controller/action/auth/VerifyForTwitterAction.java
+++ b/app/in/partake/controller/action/auth/VerifyForTwitterAction.java
@@ -120,12 +120,8 @@ class VerifyForTwitterActionTransaction extends Transaction<UserEx> {
         String userId = twitterLinkage.getUserId();
         User user = daos.getUserAccess().find(con, userId);
         if (user != null) {
-            if (verifyUserProfiles(user, twitterLinkage)) {
+            if (verifyUserProfiles(user, twitterLinkage))
                 return new UserEx(user, twitterLinkage);
-            } else {
-                // to update user data, the user is once removed.
-                daos.getUserAccess().remove(con, userId);
-            }
         }
 
         // If no user was associated to UserTwitterLink, we create a new user.


### PR DESCRIPTION
## Change

This correction contains to re-create UserIndex table data,
when the screenName or userProfileImageURL is different from the data provided by TwitterService.

Previously, the UserEx data which is stored in the session was not updated,
when the user is already stored in the UserIndex table.
This fix refresh the UserEx in the session, so the screenName & userProfileImageURL are got updated.

I think the occurrence of the change in screenName and Image is rare,
so this correction might not cause the performance problem,
though it recreate the UserIndex data.
(By the way, TwitterLinkage data is updated in every verification.)
## Testing

I didn't create the UnitTest, since Testing VerifyForTwitterAction needs mocking of Cache.get().
Mockito can not mock the static method.
(necessary to use PowerMock??)

I tested by hand by repeating Logout -> Login,
with changing the image-only, screenNamge-only, and image & screenName.

Now, 1 testcase is failed. This seems happened from some previous revisions. Is it right?
[info] TestAdminModifySettingAPI:
[info] - Accessing with admin user **\* FAILED ***
[info]   Expected None, but got Some(value) (TestAdminModifySettingAPI.scala:14)
## Other

I think this correction might not fixes the issue #386.
