### PR TITLE
<title> should contain event title

### DIFF
--- a/app/views/internal/mainForEvent.scala.html
+++ b/app/views/internal/mainForEvent.scala.html
@@ -34,7 +34,7 @@
 
     @internal.javascript(ctx)
     @internal.googleCodeSnippet()
-    <title>PARTAKE</title>
+    <title>@title - PARTAKE</title>
 </head>
 <body @if(ctx.loginUser() != null && EventEditPermission.check(event, ctx.loginUser)) { class="with-sub-nav" }>
 @internal.header(ctx)


### PR DESCRIPTION
To make event page 'search engine friendly', <title> should contain event title.
