### PR TITLE
Correct <head> in event page

### DIFF
--- a/app/in/partake/controller/PartakeActionContext.java
+++ b/app/in/partake/controller/PartakeActionContext.java
@@ -15,5 +15,13 @@ public interface PartakeActionContext {
 
     public abstract void addMessage(MessageCode mc);
     public abstract List<MessageCode> messages();
+    /**
+     * <p>Return URL for og:image meta data (thumbnail).
+     *
+     * @see https://developers.facebook.com/docs/opengraph/using-objects/
+     * @return null or URL for thumbnail.
+     */
+    public abstract String thumbnailURL();
+    public abstract void setThumbnailURL(String thumbnailURL);
 }
 

--- a/app/in/partake/controller/action/event/EventShowAction.java
+++ b/app/in/partake/controller/action/event/EventShowAction.java
@@ -74,6 +74,9 @@ public class EventShowAction extends AbstractPartakeAction {
         this.comments = transaction.getComments();
         this.eventMessages = transaction.getEventMessages();
 
+        if (event.getForeImageId() != null) {
+            context().setThumbnailURL("/images/thumbnail/" + event.getForeImageId());
+        }
         return render(views.html.events.show.render(context(), event, user, tickets, userTicketMap, ticketHolderListMap, comments, eventMessages));
     }
 

--- a/app/in/partake/controller/base/AbstractPartakeController.java
+++ b/app/in/partake/controller/base/AbstractPartakeController.java
@@ -25,14 +25,11 @@ import java.util.UUID;
 
 import org.apache.commons.lang.StringUtils;
 
-import com.google.common.base.Strings;
-
-import controllers.Assets;
-
 import play.Logger;
-import play.core.Router;
 import play.mvc.Controller;
 import play.mvc.Result;
+
+import com.google.common.base.Strings;
 
 public abstract class AbstractPartakeController extends Controller {
     private PartakeActionContextImpl ctx;

--- a/app/in/partake/controller/base/AbstractPartakeController.java
+++ b/app/in/partake/controller/base/AbstractPartakeController.java
@@ -27,7 +27,10 @@ import org.apache.commons.lang.StringUtils;
 
 import com.google.common.base.Strings;
 
+import controllers.Assets;
+
 import play.Logger;
+import play.core.Router;
 import play.mvc.Controller;
 import play.mvc.Result;
 
@@ -441,6 +444,7 @@ class PartakeActionContextImpl implements PartakeActionContext {
     String sessionToken;
     String currentURL;
     String redirectURL;
+    String thumbnailURL;
     List<MessageCode> messageCodes = new ArrayList<MessageCode>();
 
     public void setLoginUser(UserEx loginUser) {
@@ -490,5 +494,13 @@ class PartakeActionContextImpl implements PartakeActionContext {
     @Override
     public List<MessageCode> messages() {
         return Collections.unmodifiableList(messageCodes);
+    }
+    @Override
+    public String thumbnailURL() {
+        return thumbnailURL;
+    }
+    @Override
+    public void setThumbnailURL(String thumbnailURL) {
+        this.thumbnailURL = thumbnailURL;
     }
 }

--- a/app/views/internal/mainForEvent.scala.html
+++ b/app/views/internal/mainForEvent.scala.html
@@ -5,7 +5,7 @@
 @import in.partake.controller.base.permission._
 
 <html lang="ja">
-<head>
+<head prefix="og: http://ogp.me/ns#">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta http-equiv="Content-Script-Type" content="text/javascript">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -15,6 +15,10 @@
     } else {
     <meta name="description" content="@Util.shorten(Util.removeTags(event.getDescription()), 128)" />
     }
+    @if(ctx.thumbnailURL() != null) {
+    <meta property="og:image" content="@ctx.thumbnailURL()">
+    }
+    <meta property="og:image" content="@routes.Assets.at("images/musangas.jpg")">
 
     @internal.stylesheet(ctx)
     @if(event.getBackImageId() != null) {

--- a/app/views/internal/mainForEvent.scala.html
+++ b/app/views/internal/mainForEvent.scala.html
@@ -5,20 +5,31 @@
 @import in.partake.controller.base.permission._
 
 <html lang="ja">
-<head prefix="og: http://ogp.me/ns#">
+<head prefix="og: http://ogp.me/ns# article: http://ogp.me/ns/article#">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta http-equiv="Content-Script-Type" content="text/javascript">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     @if(!StringUtils.isEmpty(event.getSummary())) {
     <meta name="description" content="@event.getSummary()" />
+    <meta property="og:description" content="@event.getSummary()">
     } else {
     <meta name="description" content="@Util.shorten(Util.removeTags(event.getDescription()), 128)" />
+    <meta property="og:description" content="@Util.shorten(Util.removeTags(event.getDescription()), 128)">
     }
+
+    @*
+    We have to provide absolute URL, but @ctx.currentURL does not
+    contain context path and host name.
+    <meta property="og:url" content="@ctx.currentURL">
+    *@
+    <meta property="og:title" content="@title">
+    <meta property="og:site_name" content="PARTAKE">
     @if(ctx.thumbnailURL() != null) {
     <meta property="og:image" content="@ctx.thumbnailURL()">
     }
     <meta property="og:image" content="@routes.Assets.at("images/musangas.jpg")">
+    <meta property="og:type" content="article">
 
     @internal.stylesheet(ctx)
     @if(event.getBackImageId() != null) {

--- a/app/views/internal/mainForEvent.scala.html
+++ b/app/views/internal/mainForEvent.scala.html
@@ -18,17 +18,13 @@
     <meta property="og:description" content="@Util.shorten(Util.removeTags(event.getDescription()), 128)">
     }
 
-    @*
-    We have to provide absolute URL, but @ctx.currentURL does not
-    contain context path and host name.
-    <meta property="og:url" content="@ctx.currentURL">
-    *@
+    <meta property="og:url" content="@in.partake.app.PartakeConfiguration.toppath@ctx.currentURL">
     <meta property="og:title" content="@title">
     <meta property="og:site_name" content="PARTAKE">
     @if(ctx.thumbnailURL() != null) {
-    <meta property="og:image" content="@ctx.thumbnailURL()">
+    <meta property="og:image" content="@in.partake.app.PartakeConfiguration.toppath@ctx.thumbnailURL">
     }
-    <meta property="og:image" content="@routes.Assets.at("images/musangas.jpg")">
+    <meta property="og:image" content="@in.partake.app.PartakeConfiguration.toppath@routes.Assets.at("images/musangas.jpg")">
     <meta property="og:type" content="article">
 
     @internal.stylesheet(ctx)

--- a/app/views/internal/mainForEvent.scala.html
+++ b/app/views/internal/mainForEvent.scala.html
@@ -10,7 +10,7 @@
     <meta http-equiv="Content-Script-Type" content="text/javascript">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    @if(StringUtils.isEmpty(event.getSummary())) {
+    @if(!StringUtils.isEmpty(event.getSummary())) {
     <meta name="description" content="@event.getSummary()" />
     } else {
     <meta name="description" content="@Util.shorten(Util.removeTags(event.getDescription()), 128)" />

--- a/app/views/internal/mainForEvent.scala.html
+++ b/app/views/internal/mainForEvent.scala.html
@@ -7,11 +7,10 @@
 <html lang="ja">
 <head prefix="og: http://ogp.me/ns# article: http://ogp.me/ns/article#">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <meta http-equiv="Content-Script-Type" content="text/javascript">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     @if(!StringUtils.isEmpty(event.getSummary())) {
-    <meta name="description" content="@event.getSummary()" />
+    <meta name="description" content="@event.getSummary()">
     <meta property="og:description" content="@event.getSummary()">
     } else {
     <meta name="description" content="@Util.shorten(Util.removeTags(event.getDescription()), 128)" />


### PR DESCRIPTION
This request includes:
- Fix to display `<meta name="description">` correctly
- Support OGP (#196)
- Remove unnecessary closing `/` in `<meta>`
- Remove unnecessary `<meta http-equiv="Content-Script-Type">`

To correct problem perfectly, we also need to merge #450.
