### PR TITLE
435 ModifyAPI spec fix

### DIFF
--- a/app/in/partake/controller/api/event/ModifyAPI.java
+++ b/app/in/partake/controller/api/event/ModifyAPI.java
@@ -67,7 +67,7 @@ public class ModifyAPI extends AbstractPartakeAPI {
             searchService.create(event, tickets);
 
         ObjectNode obj = new ObjectNode(JsonNodeFactory.instance);
-        obj.put("eventId", eventId);
+        obj.putAll(transaction.getJSONObject());
         return renderOK(obj);
     }
 }

--- a/app/views/events/_edit_side_information.scala.html
+++ b/app/views/events/_edit_side_information.scala.html
@@ -381,12 +381,12 @@ $('#related-edit').click(function(e) {
 $('#related-submit').click(function(e) {
     var id = removeSuffix($(enclosingForm(this)).attr("id"), "-form");
 
-    var relatedEventIds = [];
+    var newRelatedEventIds = [];
     $('#related-list input').each(function(elem) {
-        relatedEventIds.push($(this).val());
+        newRelatedEventIds.push($(this).val());
     });
 
-    partake.event.modify(eventId, { relatedEventIds: relatedEventIds })
+    partake.event.modify(eventId, { relatedEventIds: newRelatedEventIds })
     .done(function (json) {
         $('#' + id + '-form').hide();
         $('#' + id + '-show').show();
@@ -395,6 +395,7 @@ $('#related-submit').click(function(e) {
         if (!json.relatedEvents)
             return;
 
+        relatedEventIds = [];
         for (var i = 0; i < json.relatedEvents.length; ++i) {
             var relatedEvent = json.relatedEvents[i];
             var li = $("<li></li>");
@@ -402,6 +403,7 @@ $('#related-submit').click(function(e) {
             a.attr('href', '/events/' + relatedEvent.id);
             a.text(relatedEvent.title);
             li.append(a);
+            relatedEventIds.push(relatedEvent.id);
 
             $('#related-content').append(li);
         }

--- a/app/views/events/_edit_side_information.scala.html
+++ b/app/views/events/_edit_side_information.scala.html
@@ -223,10 +223,11 @@ $('#place-edit').click(function(e) {
 $('#place-submit').click(function(e) {
     var form = $(enclosingForm(this));
     var id = removeSuffix(form.attr("id"), "-form");
+    var place = $('#place-input').val();
 
-    partake.event.modify(eventId, { place: $('#place-input').val() })
+    partake.event.modify(eventId, { place: place })
     .done(function (json) {
-        $('#place-content').text($('#place-input').val());
+        $('#place-content').text(place);
         $('#' + id + '-form').hide();
         $('#' + id + '-show').show();
     })
@@ -254,12 +255,12 @@ $('#address-edit').click(function(e) {
 $('#address-submit').click(function(e) {
     var form = $(enclosingForm(this));
     var id = removeSuffix(form.attr("id"), "-form");
+    var address = $('#address-input').val();
 
-    partake.event.modify(eventId, { address: $('#address-input').val() })
+    partake.event.modify(eventId, { address: address })
     .done(function (json) {
-        $('#address-content').text($('#address-input').val());
+        $('#address-content').text(address);
 
-        var address = $('#address-input').val();
         var mapURL = 'http://maps.google.co.jp/maps?q=' + encodeURIComponent(address);
         $('#address-anchor').attr('href', mapURL);
 
@@ -299,11 +300,12 @@ $('#url-edit').click(function(e) {
 $('#url-submit').click(function(e) {
     var form = $(enclosingForm(this));
     var id = removeSuffix(form.attr("id"), "-form");
+    var url = $('#url-input').val();
 
-    partake.event.modify(eventId, { url: $('#url-input').val() })
+    partake.event.modify(eventId, { url: url })
     .done(function (json) {
-        $('#url-content').text($('#url-input').val());
-        $('#url-content').attr('href', $('#url-input').val());
+        $('#url-content').text(url);
+        $('#url-content').attr('href', url);
         $('#' + id + '-form').hide();
         $('#' + id + '-show').show();
     })


### PR DESCRIPTION
このPullRequestは以下の修正を行います。詳細はコミットコメントを参照してください。
- #435
- #444
- #461
- Ajaxリクエスト成功時に「どう更新されたか」ではなく「今フォームに何が入力されているか」にもとづいてページが更新されてしまう問題
- 関連イベントを更新してから再度関連イベント編集フォームを開いた際に、更新前の関連イベントがフォーム内に表示される問題

EventのModifyAPIですが、更新後のイベントではなく更新された差分のみ返す実装になっています。
これはModifyAPI.javaに残っていた実装の再利用と、関連イベントの名称をEventオブジェクトから取得できない（EventExを使うべきだが毎回それを構築するのは手間）ことを意識したものです。Wikiはマージ後に更新します。
