### PR TITLE
fix default data of calendar control

### DIFF
--- a/app/views/events/_edit_side_information.scala.html
+++ b/app/views/events/_edit_side_information.scala.html
@@ -167,7 +167,7 @@ $('#editor-input').autocomplete({
 <div><input type="text" id="date-begin-input" name="beginDate" class="edit-input" placeholder="YYYY-MM-DD HH:MM" value="@TimeUtil.formatForEvent(event.getBeginDate())" /></div>
 <p>終了日時</p>
 <div class="input-prepend">
-    <div class="add-on"><input id="date-end-use-input" type="checkbox" class="edit-input" name="usesEndDate" @if(event.getEndDate() != null) { checked } ></div><input type="text" id="date-end-input" name="endDate" placeholder="YYYY-MM-DD HH:MM" value="@if(event.getEndDate() != null) { @TimeUtil.formatForEvent(event.getEndDate()) } else { @TimeUtil.formatForEvent(event.getBeginDate()) }" />
+    <div class="add-on"><input id="date-end-use-input" type="checkbox" class="edit-input" name="usesEndDate" @if(event.getEndDate() != null) { checked } ></div><input type="text" id="date-end-input" name="endDate" placeholder="YYYY-MM-DD HH:MM" value="@if(event.getEndDate() != null) {@TimeUtil.formatForEvent(event.getEndDate())} else {@TimeUtil.formatForEvent(event.getBeginDate())}" />
 </div>
 <div class="edit-form-buttons">
     <input type="button" value="キャンセル" class="btn edit-cancel-button">


### PR DESCRIPTION
previously html of this input element has space like
`value=" 2017-06-01 16:00 "`, but it should be `value="2017-06-01 16:00"`.

This pull request will fix #460.
