### PR TITLE
fix default data of calendar control Edit

### DIFF
--- a/app/views/events/_edit_manage_navigation.scala.html
+++ b/app/views/events/_edit_manage_navigation.scala.html
@@ -17,10 +17,13 @@ $(document).on("click", "a[href!=#]", function(e){
     function isLinkInTinyMce() {
         return $(that).parents('[class^=mce]').length > 0;
     }
+    function isLinkInDateEdit() {
+        return $(that).parents('.ui-datepicker-header').length > 0;
+    }
     function isEditing() {
         return $("input[type=button]").filter(":visible:enabled").length > 0;
     }
-    if (!isLinkInTinyMce() && isEditing() &&
+    if (!isLinkInTinyMce() && !isLinkInDateEdit() && isEditing() &&
             !window.confirm("保存していない変更があります。保存しないまま編集を終了し、次のページに行く場合は「OK」を押してください。")) {
         // cancel saving, and continue to edit
         e.preventDefault();

--- a/app/views/events/_edit_side_information.scala.html
+++ b/app/views/events/_edit_side_information.scala.html
@@ -167,7 +167,7 @@ $('#editor-input').autocomplete({
 <div><input type="text" id="date-begin-input" name="beginDate" class="edit-input" placeholder="YYYY-MM-DD HH:MM" value="@TimeUtil.formatForEvent(event.getBeginDate())" /></div>
 <p>終了日時</p>
 <div class="input-prepend">
-    <div class="add-on"><input id="date-end-use-input" type="checkbox" class="edit-input" name="usesEndDate" @if(event.getEndDate() != null) { checked } ></div><input type="text" id="date-end-input" name="endDate" placeholder="YYYY-MM-DD HH:MM" value="@if(event.getEndDate() != null) { @TimeUtil.formatForEvent(event.getEndDate()) } else { @TimeUtil.formatForEvent(event.getBeginDate()) }" />
+    <div class="add-on"><input id="date-end-use-input" type="checkbox" class="edit-input" name="usesEndDate" @if(event.getEndDate() != null) { checked } ></div><input type="text" id="date-end-input" name="endDate" placeholder="YYYY-MM-DD HH:MM" value="@if(event.getEndDate() != null) {@TimeUtil.formatForEvent(event.getEndDate())} else {@TimeUtil.formatForEvent(event.getBeginDate())}" />
 </div>
 <div class="edit-form-buttons">
     <input type="button" value="キャンセル" class="btn edit-cancel-button">


### PR DESCRIPTION
previously html of this input element has space like
`value=" 2017-06-01 16:00 "`, but it should be `value="2017-06-01 16:00"`.

This pull request will fix #460 except for 'change date without click' problem.
I cannot find why this problem happens. Our code is almost same to [sample code](http://jqueryui.com/datepicker/).

So I think we have to keep #460 opened.
