### PR TITLE
close #451: Fix invalid HTML

### DIFF
--- a/app/views/admin/index.scala.html
+++ b/app/views/admin/index.scala.html
@@ -40,10 +40,10 @@
             @for(key <- in.partake.resource.ConfigurationKeyConstants.configurationkeySet) {
                 <form class="form-horizontal"><fieldset>
                 <div class="control-group">
-                    <label class="control-label" for="input01">@key</label>
+                    <label class="control-label" for="input-@key">@key</label>
                     <div class="controls">
                         <input type="hidden" name="sessionToken" value="@ctx.sessionToken()">
-                        <input type="text" class="span8" name="key" value="@if(configurationMap.get(key) != null) { @configurationMap.get(key) }"  onclick="return false;">
+                        <input type="text" id="input-@key" class="span8" name="key" value="@if(configurationMap.get(key) != null) { @configurationMap.get(key) }" onclick="return false;">
                         <input type="button" value="設定" class="btn" onclick="modifySetting($(this).form(), '@key')">
                         <span class="text-info"></span>
                     </div>

--- a/app/views/base/footer.scala.html
+++ b/app/views/base/footer.scala.html
@@ -8,8 +8,8 @@
         <div class="span12">
             <h3>About</h3>
             <p><a href="https://github.com/partakein/">Copyright &copy; The PARTAKE Committers</a></p>
-            <p><a href="http://www.worksap.co.jp/">Powered by <img src="@routes.Assets.at("/images/worksapplications.png")" alt=""></a>
-                and <a href="http://aiit.ac.jp/"><img src="@routes.Assets.at("/images/aiit-logo.png")"></a></p>
+            <p><a href="http://www.worksap.co.jp/">Powered by <img src="@routes.Assets.at("/images/worksapplications.png")" alt="Works Applications. Co.,Ltd."></a>
+                and <a href="http://aiit.ac.jp/"><img src="@routes.Assets.at("/images/aiit-logo.png")" alt="AIIT"></a></p>
             <p><a href="http://career.worksap.co.jp/newgraduate/geek/index.html">[PR] 技術者募集</a></p>
         </div>
         <div class="span6">

--- a/app/views/base/main.scala.html
+++ b/app/views/base/main.scala.html
@@ -1,8 +1,7 @@
 @(title: String)(content: Html)(implicit context: controllers.ActionContext)<!DOCTYPE html>
 <html lang="ja">
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <meta http-equiv="Content-Script-Type" content="text/javascript">
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     @base.stylesheet()

--- a/app/views/contact.scala.html
+++ b/app/views/contact.scala.html
@@ -10,8 +10,8 @@
 <h2>Powered By</h2>
 
 <div class="biglogo">
-<img src="@routes.Assets.at("/images/works-biglogo.jpg")">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-<img src="@routes.Assets.at("/images/aiit-biglogo.gif")">
+<img src="@routes.Assets.at("/images/works-biglogo.jpg")" alt="Works Applications. Co.,Ltd.">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<img src="@routes.Assets.at("/images/aiit-biglogo.gif")" alt="AIIT">
 </div>
 
 </div></div>

--- a/app/views/events/_edit_side_information.scala.html
+++ b/app/views/events/_edit_side_information.scala.html
@@ -277,7 +277,9 @@ $('#address-submit').click(function(e) {
 </script>
 
 <div class="event-map"><a id="address-anchor" href="http://maps.google.co.jp/maps?q=@if(event.getAddress() != null){@Util.encodeURIComponent(event.getAddress())}">
-    <img id="address-img" src="http://maps.google.co.jp/maps/api/staticmap?size=280x200&center=@if(event.getAddress() != null){@Util.encodeURIComponent(event.getAddress())}&zoom=17&sensor=false" />
+    <img id="address-img" src="http://maps.google.co.jp/maps/api/staticmap?size=280x200&amp;center=@if(event.getAddress() != null){@Util.encodeURIComponent(event.getAddress())}&amp;zoom=17&amp;sensor=false"
+        alt="@if(event.getAddress() != null){event.getAddress()}"
+    />
 </a></div>
 
 <h3>参考情報</h3>

--- a/app/views/events/_search.scala.html
+++ b/app/views/events/_search.scala.html
@@ -18,7 +18,7 @@
         <label class="control-label">検索語句</label>
         <div class="controls">
             <input type="text" id="search-term" name="searchTerm" />
-            <input id="search-form-button" type="submit" class="btn btn-primary" alt="Search" value="Search" />
+            <input id="search-form-button" type="submit" class="btn btn-primary" value="Search" />
         </div>
     </div>
     <div class="control-group">

--- a/app/views/events/_show_enroll.scala.html
+++ b/app/views/events/_show_enroll.scala.html
@@ -26,15 +26,15 @@
 
         <div class="span8"><div class="row">
         @if(!ticket.acceptsApplication(event, TimeUtil.getCurrentDateTime())) {
-             <span href="#" class="btn btn-flat span8 btn-enroll p2-height border-box disabled"><span class="btn-enroll-inner">申込期間外です</span></span>
+             <span class="btn btn-flat span8 btn-enroll p2-height border-box disabled"><span class="btn-enroll-inner">申込期間外です</span></span>
         } else {
             @if(user == null) {
-                <span href="#" class="btn btn-flat span8 btn-enroll p2-height border-box disabled"><span class="btn-enroll-inner">参加するには<a href="#" rel="tooltip" title="twitter でログイン" onclick="document.loginByTwitterForm.submit()"><strong>ログイン</strong></a>が必要です</span></span>
+                <span class="btn btn-flat span8 btn-enroll p2-height border-box disabled"><span class="btn-enroll-inner">参加するには<a href="#" rel="tooltip" title="twitter でログイン" onclick="document.loginByTwitterForm.submit()"><strong>ログイン</strong></a>が必要です</span></span>
             } else {
                 @if(ParticipationStatus.ENROLLED.equals(status) || ParticipationStatus.RESERVED.equals(status)) {
-                    <span href="#" class="btn c button-apply-ticket span8 btn-enroll border-box p2-height" data-ticket="@ticket.getId().toString()"><span class="btn-enroll-inner">申込変更</span></span>
+                    <span class="btn c button-apply-ticket span8 btn-enroll border-box p2-height" data-ticket="@ticket.getId().toString()"><span class="btn-enroll-inner">申込変更</span></span>
                 } else {
-                    <span href="#" class="btn btn-danger-flat button-apply-ticket span8 btn-enroll border-box p2-height" data-ticket="@ticket.getId().toString()"><span class="btn-enroll-inner">参加申込</span></span>
+                    <span class="btn btn-danger-flat button-apply-ticket span8 btn-enroll border-box p2-height" data-ticket="@ticket.getId().toString()"><span class="btn-enroll-inner">参加申込</span></span>
                 }
             }
         }

--- a/app/views/events/_show_manage_navigation.scala.html
+++ b/app/views/events/_show_manage_navigation.scala.html
@@ -7,7 +7,7 @@
 <div class="subnav subnav-fixed"><div class="container">
     <ul class="nav nav-pills nav-stacked-if-phone">
         <li class="dropdown">
-            <a class="dropdown-toggle" data-toggle="dropdown" href="#"><img class="hidden-phone-inline" src="@routes.Assets.at("/images/gear.png")"/> イベント編集<b class="caret"></b></a>
+            <a class="dropdown-toggle" data-toggle="dropdown" href="#"><img alt="" class="hidden-phone-inline" src="@routes.Assets.at("/images/gear.png")"/> イベント編集<b class="caret"></b></a>
             <ul class="dropdown-menu">
                 <li><a href="/events/edit/basic/@event.getId()">イベントを編集</a></li>
                 <li><a href="/events/edit/ticket/@event.getId()">チケットを編集</a></li>
@@ -30,13 +30,13 @@
             })
             </script>
         </li>
-        <li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="#"><img class="hidden-phone-inline" src="@routes.Assets.at("/images/momonga1.png")"/> 参加者管理<b class="caret"></b></a>
+        <li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="#"><img alt="" class="hidden-phone-inline" src="@routes.Assets.at("/images/momonga1.png")"/> 参加者管理<b class="caret"></b></a>
             <ul class="dropdown-menu">
                 <li><a href="/events/participants/@event.getId()">参加者一覧を表示</a></li>
                 <li><a href="/events/participants/csv/@event.getId()">参加者リストを CSV (UTF-8) で出力</a></li>
             </ul>
         </li>
-        <li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="#"><b><img class="hidden-phone-inline" src="@routes.Assets.at("/images/mail.png")"/></b> メッセージ管理<b class="caret"></b></a>
+        <li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="#"><b><img alt="" class="hidden-phone-inline" src="@routes.Assets.at("/images/mail.png")"/></b> メッセージ管理<b class="caret"></b></a>
             <ul class="dropdown-menu">
                 <li><a data-toggle="modal" href="#message-send-dialog">参加者へメッセージ送信</a></li>
                 <li class="divider"></li>
@@ -195,7 +195,7 @@
         <h3>リマインダーなどの送付状況</h3>
     </div>
     <div class="modal-body">
-        <div id="event-reminder-dialog-spinner"><img src="@routes.Assets.at("/images/spinner.gif")"></div>
+        <div id="event-reminder-dialog-spinner"><img alt="loading..." src="@routes.Assets.at("/images/spinner.gif")"></div>
         <ul id="event-reminder-list">
         </ul>
     </div>

--- a/app/views/events/_show_side_information.scala.html
+++ b/app/views/events/_show_side_information.scala.html
@@ -31,7 +31,9 @@
 @if(!StringUtils.isBlank(event.getAddress())) {
 <p>住所: @event.getAddress()</p>
 <div class="event-map"><a href="http://maps.google.co.jp/maps?q=@Util.encodeURIComponent(event.getAddress())">
-    <img src="http://maps.google.co.jp/maps/api/staticmap?size=280x200&center=@Util.encodeURIComponent(event.getAddress())&zoom=17&sensor=false" />
+    <img src="http://maps.google.co.jp/maps/api/staticmap?size=280x200&amp;center=@Util.encodeURIComponent(event.getAddress())&amp;zoom=17&amp;sensor=false"
+        alt="@if(event.getAddress() != null){event.getAddress()}"
+    />
 </a></div>
 }
 @if(event.getUrl() != null && !event.getUrl().isEmpty()) {

--- a/app/views/events/edit_basic.scala.html
+++ b/app/views/events/edit_basic.scala.html
@@ -177,9 +177,9 @@ $(function() {
         <input type="hidden" id="backimage-id" value="@event.getBackImageId()" />
         <div class="event-image">
             @if(StringUtils.isBlank(event.getBackImageId())) {
-                <img id="backimage-editimage" src="@routes.Assets.at("/images/no-image.png")">
+                <img id="backimage-editimage" src="@routes.Assets.at("/images/no-image.png")" alt="">
             } else {
-                <img id="backimage-editimage" src="/images/@event.getBackImageId()">
+                <img id="backimage-editimage" src="/images/@event.getBackImageId()" alt="">
             }
         </div>
 
@@ -244,9 +244,9 @@ $(function() {
         <div id="foreimage-show">
             <div class="event-image">
                 @if(StringUtils.isBlank(event.getForeImageId())) {
-                    <img id="foreimage-showimage" src="@routes.Assets.at("/images/no-image.png")" style="display: none">
+                    <img id="foreimage-showimage" src="@routes.Assets.at("/images/no-image.png")" style="display: none" alt="">
                 } else {
-                    <img id="foreimage-showimage" src="/images/@event.getForeImageId()">
+                    <img id="foreimage-showimage" src="/images/@event.getForeImageId()" alt="">
                 }
             </div>
             <span id="foreimage-edit" class="label label-edit edit-button">この位置への掲載画像を編集</span>
@@ -255,9 +255,9 @@ $(function() {
             <input type="hidden" id="foreimage-id" value="@event.getForeImageId()" />
             <div class="event-image">
                 @if(StringUtils.isBlank(event.getForeImageId())) {
-                    <img id="foreimage-editimage" src="@routes.Assets.at("/images/no-image.png")">
+                    <img id="foreimage-editimage" src="@routes.Assets.at("/images/no-image.png")" alt="">
                 } else {
-                    <img id="foreimage-editimage" src="/images/@event.getForeImageId()">
+                    <img id="foreimage-editimage" src="/images/@event.getForeImageId()" alt="">
                 }
             </div>
 

--- a/app/views/events/edit_ticket.scala.html
+++ b/app/views/events/edit_ticket.scala.html
@@ -43,10 +43,10 @@
                     <label class="control-label">募集開始日時</label>
                     <div class="controls">
                         <label class="radio"><input id="template-start-anytime" type="radio" name="applicationStart" value="anytime" checked />今から</label>
-                        <label class="radio"><input id="template-start-before" type="radio" name="applicationStart" value="from_nday_before" />イベントの <input type="text" class="span2" name="applicationStartDayBeforeEvent" value="0" /> 日前から</label>
-                        <label class="radio"><input id="template-start-custom" type="radio" name="applicationStart" value="from_custom_day" />次の日付から
-                            <input type="text" type="text" name="customApplicationStartDate" class="edit-date" placeholder="YYYY-MM-DD hh:mm" />
-                        </label>
+                        <div class="radio"><input id="template-start-before" type="radio" name="applicationStart" value="from_nday_before" /><label for="template-start-before" style="display:inline;">イベントの </label><input type="text" class="span2" name="applicationStartDayBeforeEvent" value="0" /><label for="template-start-before" style="display:inline;"> 日前から</label></div>
+                        <div class="radio"><input id="template-start-custom" type="radio" name="applicationStart" value="from_custom_day" /><label for="template-start-custom" style="display:inline;">次の日付から </label>
+                            <input type="text" name="customApplicationStartDate" class="edit-date" placeholder="YYYY-MM-DD hh:mm" />
+                        </div>
                         <p class="help-block">YYYY-MM-DD hh:mm 形式で入力します。</p>
                     </div>
                 </div>
@@ -55,10 +55,10 @@
                     <div class="controls">
                         <label class="radio"><input type="radio" name="applicationEnd" value="till_time_before_event" checked />イベントが始まるまで</label>
                         <label class="radio"><input type="radio" name="applicationEnd" value="till_time_after_event" checked />イベントが終わるまで</label>
-                        <label class="radio"><input type="radio" name="applicationEnd" value="till_nday_before" />イベントの <input type="text" class="span2" name="applicationEndDayBeforeEvent" value="0" /> 日前まで</label>
-                        <label class="radio"><input type="radio" name="applicationEnd" value="till_custom_day" />次の日付まで
-                            <input type="text" type="text" name="customApplicationEndDate" class="edit-date" placeholder="YYYY-MM-DD hh:mm"/>
-                        </label>
+                        <div class="radio"><input type="radio" name="applicationEnd" value="till_nday_before" id="template-application-end-till-nday-before" /><label style="display:inline;" for="template-application-end-till-nday-before">イベントの </label><input type="text" class="span2" name="applicationEndDayBeforeEvent" value="0" /><label style="display:inline;" for="template-application-end-till-nday-before"> 日前まで</label></div>
+                        <div class="radio"><input type="radio" name="applicationEnd" value="till_custom_day" id="template-application-end-till-custom_day" /><label for="template-application-end-till-custom_day" style="display:inline;">次の日付まで</label>
+                            <input type="text" name="customApplicationEndDate" class="edit-date" placeholder="YYYY-MM-DD hh:mm"/>
+                        </div>
                         <p class="help-block">YYYY-MM-DD hh:mm 形式で入力します。</p>
                     </div>
                 </div>
@@ -66,11 +66,16 @@
                     <label class="control-label">仮参加締切日時</label>
                     <div class="controls">
                         <label class="radio"><input type="radio" name="reservationEnd" value="till_time_before_application" checked />申込締切と同じ</label>
-                        <label class="radio"><input type="radio" name="reservationEnd" value="till_nhour_before" />申込締切の <input type="text" class="span2" name="reservationEndHourBeforeApplication" value="0" /> 時間前まで</label>
+                        <div class="radio">
+                            <input type="radio" name="reservationEnd" value="till_nhour_before" id="template-reservation-end-till-nhour-before" />
+                            <label for="template-reservation-end-till-nhour-before" style="display:inline;">申込締切の </label>
+                            <input type="text" class="span2" name="reservationEndHourBeforeApplication" value="0" />
+                            <label for="template-reservation-end-till-nhour-before" style="display:inline;"> 時間前まで</label></div>
                         <label class="radio"><input type="radio" name="reservationEnd" value="till_none" />仮参加を認めない</label>
-                        <label class="radio"><input type="radio" name="reservationEnd" value="till_custom_day" />次の日付まで
-                            <input type="text" type="text" name="customReservationEndDate" class="edit-date" placeholder="YYYY-MM-DD hh:mm" />
-                        </label>
+                        <div class="radio"><input type="radio" name="reservationEnd" value="till_custom_day" id="template-reservation-end-till-custom-day" />
+                            <label for="template-reservation-end-till-custom-day" style="display:inline;">次の日付まで</label>
+                            <input type="text" name="customReservationEndDate" class="edit-date" placeholder="YYYY-MM-DD hh:mm" />
+                        </div>
                         <p class="help-block">YYYY-MM-DD hh:mm 形式で入力します。</p>
                     </div>
                 </div>
@@ -78,16 +83,22 @@
                     <label class="control-label">価格</label>
                     <div class="controls">
                         <label class="radio"><input type="radio" name="priceType" value="free" checked />無料</label>
-                        <label class="radio"><input type="radio" name="priceType" value="nonfree" />
-                        <input type="text" class="span4" name="price" value="1000" />円 (会場で支払い)</label>
+                        <div class="radio">
+                            <input type="radio" name="priceType" value="nonfree" id="template-price-type-nonfree" />
+                            <input type="text" class="span4" name="price" value="1000" />
+                            <label for="template-price-type-nonfree" style="display:inline;">円 (会場で支払い)</label>
+                        </div>
                     </div>
                 </div>
                 <div class="control-group">
                     <label class="control-label">チケット枚数</label>
                     <div class="controls">
                         <label class="radio"><input type="radio" name="amountType" value="unlimited" checked />無制限</label>
-                        <label class="radio"><input type="radio" name="amountType" value="limited" />
-                            <input type="text" class="span2" name="amount" value="10" />枚</label>
+                        <div class="radio">
+                            <input type="radio" name="amountType" value="limited" id="template-amount-type-limited" />
+                            <input type="text" class="span2" name="amount" value="10" />
+                            <label for="template-amount-type-limited" style="display:inline;">枚</label>
+                        </div>
                     </div>
                 </div>
             </fieldset></form>
@@ -139,7 +150,7 @@ function cloneTemplate(newPrefix) {
     var cloned = template.clone(true);
     cloned.find("[id^=template]").each(function() {
         var id = $(this).attr('id').replace('template', newPrefix);
-        $(this).attr('id', id);
+        $(this).attr('id', id).siblings('label').attr('for', id);
     });
     cloned.attr('id', newPrefix);
     cloned.find('.edit-date').datetimepicker({

--- a/app/views/events/participants/_show_participants_table.scala.html
+++ b/app/views/events/participants/_show_participants_table.scala.html
@@ -35,7 +35,7 @@
             }
             @* Enquete information if any *@
             @if(event.getEnquetes() != null && !event.getEnquetes().isEmpty()) {
-                <th colspan="@(event.getEnquetes().size() - 1)">アンケートの回答</th>
+                <th colspan="@(event.getEnquetes().size())">アンケートの回答</th>
             }
         </tr>
         <tr>

--- a/app/views/events/show.scala.html
+++ b/app/views/events/show.scala.html
@@ -32,7 +32,7 @@
     <p>
         <span class="label label-info">@EventCategory.getReadableCategoryName(event.getCategory())</span>
     <p>
-</div>
+</div>@* close .page-header *@
 
 <div id="social-plugins" class="row">
     <script>
@@ -64,7 +64,7 @@
         $('#social-plugins').html(socialPluginHTML);
     });
     </script>
-</div>
+</div>@* close #social-plugins *@
 
 @events._show_enroll(ctx, event, user, tickets, userTicketMap)
 
@@ -126,7 +126,7 @@
 
 @events._show_enroll(ctx, event, user, tickets, userTicketMap)
 
-</div>
+</div>@* close .content-body *@
 @events._show_forms(ctx, event, user, tickets, userTicketMap, ticketHolderListMap, comments, eventMessages)
-</div></div>
+</div>@* close .container *@
 }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -25,9 +25,9 @@
     <div class="span16">
         @if(ctx.loginUser() != null) {
         <h3>近日開催の参加予定イベント</h3>
-        <div id="upcoming-participating-events"><img src="@routes.Assets.at("images/spinner.gif")"></div>
+        <div id="upcoming-participating-events"><img alt="loading..." src="@routes.Assets.at("images/spinner.gif")"></div>
         <h3>近日開催の管理イベント</h3>
-        <div id="upcoming-managing-events"><img src="@routes.Assets.at("images/spinner.gif")"></div>
+        <div id="upcoming-managing-events"><img alt="loading..." src="@routes.Assets.at("images/spinner.gif")"></div>
         <script>
         partake.account.getTickets('upcoming', 0, 10)
         .done(function(json) {

--- a/app/views/internal/footer.scala.html
+++ b/app/views/internal/footer.scala.html
@@ -9,8 +9,8 @@
         <div class="span12">
             <h3>About</h3>
             <p><a href="https://github.com/partakein/">Copyright &copy; The PARTAKE Committers</a></p>
-            <p><a href="http://www.worksap.co.jp/">Powered by <img src="@routes.Assets.at("/images/worksapplications.png")" alt=""></a>
-                and <a href="http://aiit.ac.jp/"><img src="@routes.Assets.at("/images/aiit-logo.png")"></a></p>
+            <p><a href="http://www.worksap.co.jp/">Powered by <img src="@routes.Assets.at("/images/worksapplications.png")" alt="Works Applications. Co.,Ltd."></a>
+                and <a href="http://aiit.ac.jp/"><img src="@routes.Assets.at("/images/aiit-logo.png")" alt="AIIT"></a></p>
             <p><a href="http://career.worksap.co.jp/newgraduate/geek/index.html">[PR] 技術者募集</a></p>
         </div>
         <div class="span6">

--- a/app/views/internal/javascript.scala.html
+++ b/app/views/internal/javascript.scala.html
@@ -5,7 +5,7 @@
 
     <script type="text/javascript" src="@routes.Assets.at("javascripts/jquery/jquery.min.js")"></script>
     <script type="text/javascript" src="@routes.Assets.at("javascripts/jquery/jquery-ui.min.js")"></script>
-    <script type="text/javascript" src="@routes.Assets.at("javascripts/partake-all.min.js")?@PartakeApp.initializedAt.getTime())"></script>
+    <script type="text/javascript" src="@routes.Assets.at("javascripts/partake-all.min.js")?@PartakeApp.initializedAt.getTime()"></script>
     <script type="text/javascript" src="http://www.google.com/jsapi"></script>
 
     @* Supports HTML5 elements for IE6-8. *@

--- a/app/views/internal/main.scala.html
+++ b/app/views/internal/main.scala.html
@@ -1,8 +1,7 @@
 @(ctx: in.partake.controller.PartakeActionContext, title: String)(content: Html)<!DOCTYPE html>
 <html lang="ja">
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <meta http-equiv="Content-Script-Type" content="text/javascript">
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     @internal.stylesheet(ctx)

--- a/app/views/internal/mainForEvent.scala.html
+++ b/app/views/internal/mainForEvent.scala.html
@@ -6,7 +6,7 @@
 
 <html lang="ja">
 <head prefix="og: http://ogp.me/ns# article: http://ogp.me/ns/article#">
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     @if(!StringUtils.isEmpty(event.getSummary())) {

--- a/app/views/internal/mainForIndex.scala.html
+++ b/app/views/internal/mainForIndex.scala.html
@@ -2,8 +2,7 @@
 
 <html lang="ja">
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <meta http-equiv="Content-Script-Type" content="text/javascript">
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     @additionalHeader


### PR DESCRIPTION
だいたいこんなことをやっています。
- `alt`属性の追加
- 不正な属性の削除
  - `type`属性を複数持つ`<input>`要素の特定と修正
  - `href`属性を持つ`<span>`要素の特定と修正
- `label`要素が複数の`<input>`要素を含むケースを排除
- HTML属性に含まれる`&`を`&amp;`で置換
- 不要な閉じタグの削除
- 参加者リストページの`colspan`属性の値を修正 （これは機能上もバグと言えます）
- #451 でオススメいただいた修正 
