### PR TITLE
Ban account

### DIFF
--- a/app/assets/javascripts/partake/partake.js
+++ b/app/assets/javascripts/partake/partake.js
@@ -21,10 +21,13 @@
         partake: this,
 
         getBan: function(targetUserId) {
-            var arg = {
-                targetUserId: targetUserId
-            };
-            return $.get('/api/account/ban', arg);
+            return $.ajax({
+                url: '/api/account/ban',
+                data: {
+                    targetUserId: targetUserId
+                },
+                cache: false
+            });
         },
 
         ban: function(targetUserId, targetState) {

--- a/app/assets/javascripts/partake/partake.js
+++ b/app/assets/javascripts/partake/partake.js
@@ -20,6 +20,22 @@
     Partake.prototype.account = {
         partake: this,
 
+        getBan: function(targetUserId) {
+            var arg = {
+                targetUserId: targetUserId
+            };
+            return $.get('/api/account/ban', arg);
+        },
+
+        ban: function(targetUserId, targetState) {
+            var arg = {
+                sessionToken: partake.sessionToken,
+                targetUserId: targetUserId,
+                targetState: targetState
+            };
+            return $.post('/api/account/ban', arg);
+        },
+
         // Gets events of account.
         getEvents: function(queryType, offset, limit) {
             var arg = {

--- a/app/in/partake/controller/action/auth/VerifyForTwitterAction.java
+++ b/app/in/partake/controller/action/auth/VerifyForTwitterAction.java
@@ -121,7 +121,7 @@ class VerifyForTwitterActionTransaction extends Transaction<UserEx> {
         String userId = twitterLinkage.getUserId();
         User user = daos.getUserAccess().find(con, userId);
         if (user == null) {
-            user = new User(userId, twitterLinkage.getScreenName(), twitterLinkage.getProfileImageURL(), TimeUtil.getCurrentDateTime(), null);
+            user = new User(userId, twitterLinkage.getScreenName(), twitterLinkage.getProfileImageURL(), TimeUtil.getCurrentDateTime(), null, false);
             daos.getUserAccess().put(con, user);
             user.freeze();
         } else {

--- a/app/in/partake/controller/api/account/BanAPI.java
+++ b/app/in/partake/controller/api/account/BanAPI.java
@@ -1,0 +1,83 @@
+package in.partake.controller.api.account;
+
+import in.partake.base.PartakeException;
+import in.partake.controller.api.AbstractPartakeAPI;
+import in.partake.model.IPartakeDAOs;
+import in.partake.model.UserEx;
+import in.partake.model.access.DBAccess;
+import in.partake.model.dao.DAOException;
+import in.partake.model.dao.PartakeConnection;
+import in.partake.model.dao.access.IUserAccess;
+import in.partake.model.dto.User;
+import in.partake.resource.UserErrorCode;
+import play.Logger;
+import play.mvc.Result;
+
+public class BanAPI extends AbstractPartakeAPI {
+
+    public static Result post() throws DAOException, PartakeException {
+        return new BanAPI().execute();
+    } 
+
+    @Override
+    public Result doExecute() throws DAOException, PartakeException {
+        ensureValidSessionToken();
+        UserEx user = ensureAdmin();
+
+        String targetUserId = getFormParameter("targetUserId");
+        boolean state = getBooleanParameter("targetState"); // true if administrator wants to ban
+
+        BanAPITransaction transaction = new BanAPITransaction(user.getId(), targetUserId, state);
+        User bannedUser = transaction.execute();
+        if (bannedUser == null) {
+            return renderInvalid(UserErrorCode.INVALID_ARGUMENT);
+        } else {
+            // Admin専用APIなのでtoSafeJSONの代わりにtoJSONを呼ぶ
+            return renderOK(bannedUser.toJSON());
+        }
+    }
+}
+
+class BanAPITransaction extends DBAccess<User> {
+    private final String userId;
+    private final String targetUserId;
+    private final boolean targetState;
+
+    public BanAPITransaction(String userId, String targetUserId, boolean state) {
+        this.userId = userId;
+        this.targetUserId = targetUserId;
+        this.targetState = state;
+    }
+
+    @Override
+    protected User doExecute(PartakeConnection con, IPartakeDAOs daos) throws DAOException, PartakeException {
+        IUserAccess access = daos.getUserAccess();
+        User targetUser = access.find(con, targetUserId);
+        if (targetUser == null) {
+            Logger.info("No user has specified ID: " + targetUserId);
+            return null;
+        } else if (targetState == targetUser.isBanned()) {
+            if (targetState) {
+                Logger.info(String.format(
+                        "No need to ban: specified user (%s) is already banned",
+                        targetUser.getId()));
+            } else {
+                Logger.info(String.format(
+                        "No need to recover: specified user (%s) is not banned yet",
+                        targetUser.getId()));
+            }
+            return null;
+        }
+
+        targetUser = new User(targetUser);
+        targetUser.setBanned(targetState);
+        access.put(con, targetUser);
+        Logger.info(String.format(
+                "Administrator (%s) changed state of user (%s) to %s",
+                userId,
+                targetUser.getId(),
+                targetState ? "BANNED" : "NOT BANNED"));
+
+        return targetUser;
+    }
+}

--- a/app/in/partake/controller/api/account/GetBanAPI.java
+++ b/app/in/partake/controller/api/account/GetBanAPI.java
@@ -1,0 +1,59 @@
+package in.partake.controller.api.account;
+
+import in.partake.base.PartakeException;
+import in.partake.controller.api.AbstractPartakeAPI;
+import in.partake.model.IPartakeDAOs;
+import in.partake.model.UserEx;
+import in.partake.model.access.DBAccess;
+import in.partake.model.dao.DAOException;
+import in.partake.model.dao.PartakeConnection;
+import in.partake.model.dao.access.IUserAccess;
+import in.partake.model.dto.User;
+import in.partake.resource.UserErrorCode;
+import play.Logger;
+import play.mvc.Result;
+
+public class GetBanAPI extends AbstractPartakeAPI {
+
+    public static Result get() throws DAOException, PartakeException {
+        return new GetBanAPI().execute();
+    } 
+
+    @Override
+    public Result doExecute() throws DAOException, PartakeException {
+        UserEx user = ensureAdmin();
+        String targetUserId = getQueryStringParameter("targetUserId");
+
+        GetBanAPITransaction transaction = new GetBanAPITransaction(user.getId(), targetUserId);
+        User targetUser = transaction.execute();
+        if (targetUser == null) {
+            return renderInvalid(UserErrorCode.INVALID_ARGUMENT);
+        } else {
+            // Admin専用APIなのでtoSafeJSONの代わりにtoJSONを呼ぶ
+            return renderOK(targetUser.toJSON());
+        }
+    }
+}
+
+class GetBanAPITransaction extends DBAccess<User> {
+    private final String userId;
+    private final String targetUserId;
+
+    public GetBanAPITransaction(String userId, String targetUserId) {
+        this.userId = userId;
+        this.targetUserId = targetUserId;
+    }
+
+    @Override
+    protected User doExecute(PartakeConnection con, IPartakeDAOs daos) throws DAOException, PartakeException {
+        IUserAccess access = daos.getUserAccess();
+        User targetUser = access.find(con, targetUserId);
+        if (targetUser == null) {
+            Logger.info("No user has specified ID: " + targetUserId);
+            return null;
+        }
+
+        Logger.info("Administrator(" + userId + ") researched that specified user (" + targetUserId + ") is banned or not.");
+        return targetUser;
+    }
+}

--- a/app/in/partake/controller/api/event/CreateAPI.java
+++ b/app/in/partake/controller/api/event/CreateAPI.java
@@ -33,6 +33,9 @@ public class CreateAPI extends AbstractPartakeAPI {
     protected Result doExecute() throws DAOException, PartakeException {
         UserEx user = ensureLogin();
         ensureValidSessionToken();
+        if (user.isBanned()) {
+            throw new PartakeException(UserErrorCode.BANNED_USER);
+        }
 
         Event embryo = new Event();
         embryo.setOwnerId(user.getId());

--- a/app/in/partake/model/dto/User.java
+++ b/app/in/partake/model/dto/User.java
@@ -12,17 +12,22 @@ public class User extends PartakeModel<User> {
     private String profileImageURL;
     private DateTime createdAt;
     private DateTime modifiedAt;
+    /**
+     * true if system administrator banned this account
+     */
+    private boolean isBanned;
 
-    public User(String id, String screenName, String profileImageURL, DateTime createdAt, DateTime modifiedAt) {
+    public User(String id, String screenName, String profileImageURL, DateTime createdAt, DateTime modifiedAt, boolean isBanned) {
         this.id = id;
         this.screenName = screenName;
         this.profileImageURL = profileImageURL;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
+        this.isBanned = isBanned;
     }
 
     public User(User user) {
-        this(user.id, user.screenName, user.profileImageURL, user.createdAt, user.modifiedAt);
+        this(user.id, user.screenName, user.profileImageURL, user.createdAt, user.modifiedAt, user.isBanned);
     }
 
     public User(ObjectNode obj) {
@@ -32,6 +37,9 @@ public class User extends PartakeModel<User> {
         this.createdAt = new DateTime(obj.get("createdAt").asLong());
         if (obj.has("modifiedAt"))
             this.modifiedAt = new DateTime(obj.get("modifiedAt").asLong());
+        if (obj.has("isBanned")) {
+            this.isBanned = obj.get("isBanned").asBoolean();
+        }
     }
 
     @Override
@@ -78,6 +86,7 @@ public class User extends PartakeModel<User> {
         if (!ObjectUtils.equals(lhs.profileImageURL, rhs.profileImageURL)) { return false; }
         if (!ObjectUtils.equals(lhs.createdAt, rhs.createdAt)) { return false; }
         if (!ObjectUtils.equals(lhs.modifiedAt, rhs.modifiedAt)) { return false; }
+        if (!ObjectUtils.equals(lhs.isBanned, rhs.isBanned)) { return false; }
         return true;
     }
 
@@ -109,6 +118,10 @@ public class User extends PartakeModel<User> {
         return modifiedAt;
     }
 
+    public boolean isBanned() {
+        return isBanned;
+    }
+
     public void setId(String id) {
         checkFrozen();
         this.id = id;
@@ -133,4 +146,10 @@ public class User extends PartakeModel<User> {
         checkFrozen();
         this.modifiedAt = modifiedAt;
     }
+
+    public void setBanned(boolean isBanned) {
+        checkFrozen();
+        this.isBanned = isBanned;
+    }
+
 }

--- a/app/in/partake/model/dto/User.java
+++ b/app/in/partake/model/dto/User.java
@@ -68,6 +68,7 @@ public class User extends PartakeModel<User> {
         obj.put("createdAt", createdAt.getTime());
         if (modifiedAt != null)
             obj.put("modifiedAt", modifiedAt.getTime());
+        obj.put("isBanned", isBanned);
         return obj;
     }
 

--- a/app/in/partake/resource/UserErrorCode.java
+++ b/app/in/partake/resource/UserErrorCode.java
@@ -63,6 +63,7 @@ public enum UserErrorCode {
     MISSING_USER_ID("invalid.missing_userid"),
     INVALID_USER_PRIVATE("invalid.user.profile.private", 403),
     MISSING_USERNAME("invalid.user.username.missing"),
+    BANNED_USER("invalid.user.banned", 403),
 
     // OPEN_ID
     INVALID_OPENID("invalid.invalid_openid"),

--- a/app/views/users/show.scala.html
+++ b/app/views/users/show.scala.html
@@ -3,6 +3,33 @@
 
 <div class="page-header">
 	<h1>@user.getScreenName()</h1>
+    @if(ctx.loginUser != null && ctx.loginUser.isAdministrator()) {
+        <button id="ban-user" class="btn" disabled>Loading...</button>
+        <script>
+            var $banButton = $("#ban-user").click(function(e){
+                var targetState = $(this).data("target-state"),
+                    targetUserId = "@user.getId()";
+                $banButton.prop('disabled', true);
+                partake.account.ban(targetUserId, targetState).done(function(user){
+                    updateBanButton(user);
+                }).fail(partake.defaultFailHandler);
+            });
+
+            function updateBanButton(user) {
+                if (user.isBanned) {
+                    $banButton.removeClass("btn-warning").data("target-state", false).text("イベント作成を許可する");
+                } else {
+                    $banButton.addClass("btn-warning").data("target-state", true).text("イベント作成を禁止する");
+                }
+                $banButton.prop('disabled', false);
+            }
+            $(function(){
+                partake.account.getBan("@user.getId()").done(function(user){
+                    updateBanButton(user);
+                }).fail(partake.defaultFailHandler);
+            });
+        </script>
+    }
 </div>
 
 <div class="row tabbable">

--- a/conf/i18n/resource_ja.properties
+++ b/conf/i18n/resource_ja.properties
@@ -74,6 +74,7 @@ invalid.invalid_userid = 無効な UserID です。
 invalid.missing_userid = UserID がパラメータとして渡されていません。
 invalid.user.profile.private = このユーザーはプロフィールを非公開にしています。
 invalid.user.username.missing = ユーザー名が入力されていません。
+invalid.user.banned = 管理者によってイベントの投稿が禁止されたアカウントです。
 
 invalid.invalid_openid = 無効な OpenID です。
 invalid.missing_openid = OpenID がパラメータとして渡されていません。

--- a/conf/routes
+++ b/conf/routes
@@ -77,6 +77,8 @@ GET     /api/debug/errorDB                  controllers.api.debug.ErrorDBAPI.run
 GET     /api/debug/errorDBException         controllers.api.debug.ErrorDBExceptionAPI.run()
 
 # Account API
+GET     /api/account/ban                    in.partake.controller.api.account.GetBanAPI.get()
+POST    /api/account/ban                    in.partake.controller.api.account.BanAPI.post()
 GET     /api/account/get                    in.partake.controller.api.account.GetAPI.get()
 GET     /api/account/events                 in.partake.controller.api.account.GetEventsAPI.get()
 GET     /api/account/tickets                in.partake.controller.api.account.GetTicketsAPI.get()

--- a/test/in/partake/model/dto/UserTest.java
+++ b/test/in/partake/model/dto/UserTest.java
@@ -15,9 +15,9 @@ public class UserTest extends AbstractPartakeModelTest<User> {
     @Before
     public void createSampleData() {
         samples = new User[] {
-                new User("id1", "screenName1", "http://www.example.com/1", TimeUtil.getCurrentDateTime(), null),
-                new User("id2", "screenName2", "http://www.example.com/2", TimeUtil.getCurrentDateTime(), null),
-                new User("id3", "screenName3", "http://www.example.com/3", TimeUtil.getCurrentDateTime(), null),
+                new User("id1", "screenName1", "http://www.example.com/1", TimeUtil.getCurrentDateTime(), null, false),
+                new User("id2", "screenName2", "http://www.example.com/2", TimeUtil.getCurrentDateTime(), null, false),
+                new User("id3", "screenName3", "http://www.example.com/3", TimeUtil.getCurrentDateTime(), null, false),
         };
     }
 
@@ -37,7 +37,7 @@ public class UserTest extends AbstractPartakeModelTest<User> {
 
     @Test
     public void testToJSONFromJSON() {
-        User user = new User("id1", "screenName1", "http://www.example.com/1", TimeUtil.getCurrentDateTime(), null);
+        User user = new User("id1", "screenName1", "http://www.example.com/1", TimeUtil.getCurrentDateTime(), null, false);
         Assert.assertEquals(user, new User(user.toJSON()));
     }
 

--- a/test/in/partake/model/fixture/impl/UserTestDataProvider.java
+++ b/test/in/partake/model/fixture/impl/UserTestDataProvider.java
@@ -18,18 +18,18 @@ public class UserTestDataProvider extends TestDataProvider<User> {
     @Override
     public User create(long pkNumber, String pkSalt, int objNumber) {
         UUID id = new UUID(pkNumber, ("user" + pkSalt).hashCode());
-        return new User(id.toString(), "screenName" + objNumber, "http://www.example.com/", new DateTime(0), null);
+        return new User(id.toString(), "screenName" + objNumber, "http://www.example.com/", new DateTime(0), null, false);
     }
 
     @Override
     public List<User> createSamples() {
         List<User> array = new ArrayList<User>();
-        array.add(new User("id", "screenName", "http://www.example.com/", new DateTime(0), null));
-        array.add(new User("id1", "screenName", "http://www.example.com/", new DateTime(0), null));
-        array.add(new User("id", "screenName1", "http://www.example.com/", new DateTime(0), null));
-        array.add(new User("id", "screenName", "http://www.example.com/hoge", new DateTime(0), null));
-        array.add(new User("id", "screenName", "http://www.example.com/", new DateTime(1), null));
-        array.add(new User("id", "screenName", "http://www.example.com/", new DateTime(0), new DateTime(0)));
+        array.add(new User("id", "screenName", "http://www.example.com/", new DateTime(0), null, false));
+        array.add(new User("id1", "screenName", "http://www.example.com/", new DateTime(0), null, false));
+        array.add(new User("id", "screenName1", "http://www.example.com/", new DateTime(0), null, false));
+        array.add(new User("id", "screenName", "http://www.example.com/hoge", new DateTime(0), null, false));
+        array.add(new User("id", "screenName", "http://www.example.com/", new DateTime(1), null, false));
+        array.add(new User("id", "screenName", "http://www.example.com/", new DateTime(0), new DateTime(0), false));
         return array;
     }
 
@@ -49,33 +49,33 @@ public class UserTestDataProvider extends TestDataProvider<User> {
         dao.truncate(con);
 
         for (int i = 0; i < DEFAULT_USER_IDS.length; ++i)
-            dao.put(con, new User(DEFAULT_USER_IDS[i], DEFAULT_USER_TWITTER_SCREENNAME[i], "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
+            dao.put(con, new User(DEFAULT_USER_IDS[i], DEFAULT_USER_TWITTER_SCREENNAME[i], "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
 
-        dao.put(con, new User(DEFAULT_USER_ID, DEFAULT_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
-        dao.put(con, new User(DEFAULT_ANOTHER_USER_ID, DEFAULT_ANOTHER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
-        dao.put(con, new User(ADMIN_USER_ID, ADMIN_USER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
-        dao.put(con, new User(USER_WITHOUT_PREF_ID, USER_WITHOUT_PREF_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
-        dao.put(con, new User(USER_WITH_PRIVATE_PREF_ID, USER_WITH_PRIVATE_PREF_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
+        dao.put(con, new User(DEFAULT_USER_ID, DEFAULT_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
+        dao.put(con, new User(DEFAULT_ANOTHER_USER_ID, DEFAULT_ANOTHER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
+        dao.put(con, new User(ADMIN_USER_ID, ADMIN_USER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
+        dao.put(con, new User(USER_WITHOUT_PREF_ID, USER_WITHOUT_PREF_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
+        dao.put(con, new User(USER_WITH_PRIVATE_PREF_ID, USER_WITH_PRIVATE_PREF_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
 
-        dao.put(con, new User(EVENT_OWNER_ID, EVENT_OWNER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
-        dao.put(con, new User(EVENT_EDITOR_ID, EVENT_EDITOR_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
-        dao.put(con, new User(EVENT_COMMENTOR_ID, EVENT_COMMENTOR_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
-        dao.put(con, new User(EVENT_ENROLLED_USER_ID, EVENT_ENROLLED_USER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
+        dao.put(con, new User(EVENT_OWNER_ID, EVENT_OWNER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
+        dao.put(con, new User(EVENT_EDITOR_ID, EVENT_EDITOR_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
+        dao.put(con, new User(EVENT_COMMENTOR_ID, EVENT_COMMENTOR_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
+        dao.put(con, new User(EVENT_ENROLLED_USER_ID, EVENT_ENROLLED_USER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
 
-        dao.put(con, new User(EVENT_RESERVED_USER_ID, EVENT_RESERVED_USER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
-        dao.put(con, new User(EVENT_CANCELLED_USER_ID, EVENT_CANCELLED_USER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
-        dao.put(con, new User(EVENT_UNRELATED_USER_ID, EVENT_UNRELATED_USER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
+        dao.put(con, new User(EVENT_RESERVED_USER_ID, EVENT_RESERVED_USER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
+        dao.put(con, new User(EVENT_CANCELLED_USER_ID, EVENT_CANCELLED_USER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
+        dao.put(con, new User(EVENT_UNRELATED_USER_ID, EVENT_UNRELATED_USER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
 
-        dao.put(con, new User(ATTENDANCE_PRESENT_USER_ID, ATTENDANCE_PRESENT_USER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
-        dao.put(con, new User(ATTENDANCE_ABSENT_USER_ID, ATTENDANCE_ABSENT_USER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
-        dao.put(con, new User(ATTENDANCE_UNKNOWN_USER_ID, ATTENDANCE_UNKNOWN_USER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
+        dao.put(con, new User(ATTENDANCE_PRESENT_USER_ID, ATTENDANCE_PRESENT_USER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
+        dao.put(con, new User(ATTENDANCE_ABSENT_USER_ID, ATTENDANCE_ABSENT_USER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
+        dao.put(con, new User(ATTENDANCE_UNKNOWN_USER_ID, ATTENDANCE_UNKNOWN_USER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
 
-        dao.put(con, new User(DEFAULT_SENDER_ID, DEFAULT_SENDER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
-        dao.put(con, new User(DEFAULT_RECEIVER_ID, DEFAULT_RECEIVER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
+        dao.put(con, new User(DEFAULT_SENDER_ID, DEFAULT_SENDER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
+        dao.put(con, new User(DEFAULT_RECEIVER_ID, DEFAULT_RECEIVER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
 
-        dao.put(con, new User(IMAGE_OWNER_ID, IMAGE_OWNER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
+        dao.put(con, new User(IMAGE_OWNER_ID, IMAGE_OWNER_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
 
-        dao.put(con, new User(USER_NO_TWITTER_LINK_ID, USER_NO_TWITTER_LINK_SCREEN_NAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
-        dao.put(con, new User(USER_TWITTER_NOAUTH_ID, USER_TWITTER_NOAUTH_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null));
+        dao.put(con, new User(USER_NO_TWITTER_LINK_ID, USER_NO_TWITTER_LINK_SCREEN_NAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
+        dao.put(con, new User(USER_TWITTER_NOAUTH_ID, USER_TWITTER_NOAUTH_TWITTER_SCREENNAME, "http://www.example.com/", TimeUtil.getCurrentDateTime(), null, false));
     }
 }


### PR DESCRIPTION
管理アカウントに全ユーザをBANする権限と機能を提供します。BANされたアカウントはイベントの新規作成を行えなくなります。利用停止をお願いしても引き続き投稿しているユーザがいますので、そういったユーザに対して一定の効果があると思われます。BANされている時の警告が分かりにくいことが課題ではありますが、さほど問題ではないと思います。
これがマージされたら「BANされたアカウントが管理するイベントをインデックスから削除」する機能をつけるつもりです。

ところで、APIってトランザクション管理はTransaction抽象クラスに任せていいんですよね？たまにCOMMITが遅れているのではないかと思わせる挙動を見せることがあるのですが……。
API実装で初めてのトラブル＆Userを更新するAPIはこれが初めて＝Userの更新が原因っぽい ので、1リクエストが2コネクションを使っていてそのコネクション間でUserに対する更新が衝突している可能性がありそうです。Userにロックをかけるような処理ってどこかにありました？
