### PR TITLE
キャンセルした人がいない場合のサイドバーメッセージを修正

### DIFF
--- a/app/views/events/_show_side_participants.scala.html
+++ b/app/views/events/_show_side_participants.scala.html
@@ -60,7 +60,7 @@
 
     <h3>キャンセル</h3>
     @if(list.getCancelledParticipations().isEmpty()) {
-    <p>現在補欠者はいません</p>
+    <p>現在キャンセルした人はいません</p>
     } else {
     <ol>
         @for(userTicket <- list.getCancelledParticipations()) {


### PR DESCRIPTION
キャンセルした人がいない場合、「現在補欠者はいません」と表示されるようです。
(添付画像をご参照ください)
該当部分のメッセージを修正しました。

![screen shot 2013-09-30 at 10 45 48 am](https://f.cloud.github.com/assets/194222/1234415/4fde620c-2973-11e3-9089-7720170eec78.png)
