### PR TITLE
close #495: use HTTPS instead of HTTP

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,7 +17,7 @@ object ApplicationBuild extends Build {
         "commons-lang" % "commons-lang" % "2.6",
         "org.owasp" % "antisamy" % "1.4",
         "ical4j" % "ical4j" % "0.9.20",
-        "org.twitter4j" % "twitter4j-core" % "3.0.3",
+        "org.twitter4j" % "twitter4j-core" % "3.0.5",
         "net.sf.opencsv" % "opencsv" % "2.1",
         "org.apache.lucene" % "lucene-analyzers" % "3.0.2",
         "org.openid4java" % "openid4java" % "0.9.5",


### PR DESCRIPTION
Now Twitter disallow using HTTP to access to Twitter API. We should use HTTPS.
Twitter4j supports it by default from version 3.0.5. So it is good to upgrade Twitter4j to this version.

Note that I have done this change on production environment.

See "Twitter begins requiring https on Jan 14, 2014. If you were using <= 3.0.3, update to 3.0.5" in the mailing list of Twitter4j.
